### PR TITLE
fix rename dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     reviewers:
       - "kuisathaverat"
     groups:
-      github-actions:
+      opentelemetry:
         patterns:
           - "opentelemetry-*"
 


### PR DESCRIPTION
## What does this PR do?

fix rename dependabot group
