### PR TITLE
fix: pytest fails with: INTERNALERROR (#101)

### DIFF
--- a/src/pytest_otel/__init__.py
+++ b/src/pytest_otel/__init__.py
@@ -359,7 +359,11 @@ def pytest_runtest_logreport(report):
     test_name = report.nodeid.split("::")[0]
 
     if report.failed and report.when == "teardown":
-        span = spans[test_name]
-        span.set_attribute("tests.systemerr", report.capstderr)
-        span.set_attribute("tests.systemout", report.capstdout)
-        span.set_attribute("tests.duration", getattr(report, "duration", 0.0))
+        try:
+            span = spans[test_name]
+            span.set_attribute("tests.systemerr", report.capstderr)
+            span.set_attribute("tests.systemout", report.capstdout)
+            span.set_attribute("tests.duration", getattr(report, "duration", 0.0))
+
+        except KeyError:
+            LOGGER.warning("Ignoring unknown test during teardown: {}".format(test_name))


### PR DESCRIPTION
## What does this PR do?

Catch KeyError exception during test teardowns in rare cases when test_name is not known.

## Why is it important?

Without this patch failing test results with long and confusing INTERNALERROR lines that has nothing to do with the real test.

## Related issues
Closes #101
