### PR TITLE
chore: remove reviewer field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "kuisathaverat"
     groups:
       opentelemetry:
         patterns:
@@ -20,8 +18,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "kuisathaverat"
 
   - package-ecosystem: "composer"
     directory: "tests/docker-compose.yml"
@@ -29,8 +25,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "kuisathaverat"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -38,5 +32,3 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "kuisathaverat"


### PR DESCRIPTION
## What does this PR do?

chore: remove reviewer field

## Why is it important?

It is deprecated
