### PR TITLE
Change pytest version from pinning to allow later versions too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ authors = [
   {name = "Ivan Fernandez Calvo (kuisathaverat)"}
 ]
 dependencies = [
-  "opentelemetry-api==1.41.1",
-  "opentelemetry-exporter-otlp==1.41.1",
-  "opentelemetry-sdk==1.41.1",
-  "pytest==9.0.3",
+  "opentelemetry-api>=1.41.1, <2.0.0",
+  "opentelemetry-exporter-otlp>=1.41.1, <2.0.0",
+  "opentelemetry-sdk>=1.41.1, <2.0.0",
+  "pytest>=9.0.3, <10.0.0",
 ]
 requires-python = ">= 3.10"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## What does this PR do?

This PR changes the pinned version of dependencies to allowing any version from the current release to the next major release (which may have breaking changes). 

## Why is it important?

As explained in issue #129, pinning to a specific version means that anyone using pytest_otel will be stuck on an older version of pytest or OpenTelemetry packages until a new version of pytest_otel is released. If we rely on semantic versioning we should be able to use any later version that does not have breaking changes.

## Related issues

This should resolve #129.