### PR TITLE
Bump version from 2.0.1 to 2.0.2

### DIFF
--- a/src/pytest_otel/__init__.py
+++ b/src/pytest_otel/__init__.py
@@ -24,7 +24,7 @@ from opentelemetry.trace.status import Status, StatusCode
 # from opentelemetry.ext.otcollector.metrics_exporter import CollectorMetricsExporter
 # from opentelemetry.sdk.metrics import Counter, MeterProvider
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 LOGGER = logging.getLogger("pytest_otel")
 service_name = None


### PR DESCRIPTION
## What does this PR do?

This pull request makes a minor update to the package version in `src/pytest_otel/__init__.py`, incrementing it from 2.0.1 to 2.0.2.
