### PR TITLE
chore: bump to 2.4.0

### DIFF
--- a/src/pytest_otel/__init__.py
+++ b/src/pytest_otel/__init__.py
@@ -23,7 +23,7 @@ from opentelemetry.trace.status import Status, StatusCode
 # from opentelemetry.ext.otcollector.metrics_exporter import CollectorMetricsExporter
 # from opentelemetry.sdk.metrics import Counter, MeterProvider
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 LOGGER = logging.getLogger("pytest_otel")
 service_name = None


### PR DESCRIPTION
This pull request updates the package version in `src/pytest_otel/__init__.py`.

- Versioning:
  * Bumped the `__version__` variable from `"2.3.0"` to `"2.4.0"` to reflect the latest changes.
